### PR TITLE
Adds an argument to specify which Yubikey to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ yubioath add Heroku
 Secret: ofljhedpyb
 Token: 993874
 
-$ yubioath list
+$ yubioath list --card-name "Yubikey"
 GitHub: 629283
 Heroku: 993874
 ```
@@ -44,4 +44,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/yubikey/neo.rb
+++ b/lib/yubikey/neo.rb
@@ -14,13 +14,22 @@ module Yubikey
     end
 
     def tap
-      Context.tap do |context|
-        begin
-          card = context.card(@name, :shared)
-          yield card
-        ensure
-          card.disconnect unless card.nil?
+      card_names(@name).each do |card_name|
+        Context.tap do |context|
+          begin
+            card = context.card(card_name, :shared)
+            yield card
+          ensure
+            card.disconnect unless card.nil?
+          end
         end
+      end
+    end
+
+    # Get the card names matching {name}
+    def card_names(name)
+      Context.tap do |cxt|
+        cxt.readers.select { |name| name.include?(name) }
       end
     end
 

--- a/lib/yubikey/neo.rb
+++ b/lib/yubikey/neo.rb
@@ -3,7 +3,7 @@ require 'yubioath'
 
 module Yubikey
   class Neo
-    def initialize(name: 'Yubico Yubikey NEO OTP+CCID')
+    def initialize(name:)
       @name = name
     end
 

--- a/lib/yubikey/neo/cli/yubioath.rb
+++ b/lib/yubikey/neo/cli/yubioath.rb
@@ -4,6 +4,11 @@ require 'thor'
 class Yubikey::Neo
   module CLI
     class YubiOATH < Thor
+      class_option 'card-name',
+                   desc: 'Name of the Yubikey device to use',
+                   type: :string,
+                   default: 'Yubikey'
+
       desc 'add NAME', 'Add a token'
       def add(name)
         neo.yubioath do |yubioath|
@@ -39,7 +44,7 @@ class Yubikey::Neo
       private
 
       def neo
-        @neo ||= Yubikey::Neo.new
+        @neo ||= Yubikey::Neo.new(name: options['card-name'])
       end
     end
   end


### PR DESCRIPTION
- All commands support a --card-name argument to specify a Yubikey name
- The provided name only needs to be a subset if the real card name (e.g. you can do

```
yubioath list --card-name YubiKey
```

  instead of

```
yubioath list --card-name "Yubico Yubikey NEO OTP+CCID"
```

By default, no name is provided so any device will match.
